### PR TITLE
Trigger error status event

### DIFF
--- a/.github/workflows/context.yaml
+++ b/.github/workflows/context.yaml
@@ -2,6 +2,7 @@ name: inspect context
 
 on:
   pull_request:
+  status:
 
 permissions:
   checks: write
@@ -13,6 +14,10 @@ concurrency:
 jobs:
   context:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.event.state == 'error' ||
+      github.event.state == 'failure'
     steps:
       - name: Dump GitHub context
         id: github_context_step


### PR DESCRIPTION
失敗した workflow をトリガに status event を実行した場合に使える状態を確認するのに status event でも context check workflow を実行するように修正．