### PR TITLE
Comment out trigger condition

### DIFF
--- a/.github/workflows/status_event.yaml
+++ b/.github/workflows/status_event.yaml
@@ -1,7 +1,6 @@
 name: inspect context
 
 on:
-  pull_request:
   status:
 
 permissions:


### PR DESCRIPTION
workflow 失敗時に， status event で実行される想定だったのが実行されなかったのでコメントアウトしておく & status event のだけの workflow も用意してみる(もしかすると pull_request event で実行済の為実行されないとかもあるかもしれないので)