### PR TITLE
Add types to check_run event workflow

### DIFF
--- a/.github/workflows/check_runs_event.yaml
+++ b/.github/workflows/check_runs_event.yaml
@@ -2,6 +2,7 @@ name: check_run context
 
 on:
   check_run:
+    types: [created, rerequested, completed, requested_action]
 
 permissions:
   checks: write


### PR DESCRIPTION
check_run event を定義している workflow， 調べてみるとみんな types 指定していたので足してみる．
(特にドキュメントには必須って書いてないんだけど…)

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#check_run