### PR TITLE
Remove status event `colon`

### DIFF
--- a/.github/workflows/status_event.yaml
+++ b/.github/workflows/status_event.yaml
@@ -1,7 +1,7 @@
 name: status context
 
 on:
-  status:
+  status
 
 permissions:
   checks: write


### PR DESCRIPTION
ドキュメントみると `:` を付けてないので削除してみる
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#status