### PR TITLE
Remove permissions from check_run/status event workflow

### DIFF
--- a/.github/workflows/check_runs_event.yaml
+++ b/.github/workflows/check_runs_event.yaml
@@ -4,9 +4,6 @@ on:
   check_run:
     types: [created, rerequested, completed, requested_action]
 
-permissions:
-  checks: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true

--- a/.github/workflows/status_event.yaml
+++ b/.github/workflows/status_event.yaml
@@ -3,9 +3,6 @@ name: status context
 on:
   status
 
-permissions:
-  checks: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true


### PR DESCRIPTION
check_run event を設定している repo の workflow をみると， permission を指定していないので念の為解除してみる

permission が実は trigger にも影響している…?
`checks: write` なので checks は read できるはずだけど，他に権限が必要なのかも?