### PR TITLE
Test repository & environments variables priority order

### DIFF
--- a/.github/workflows/check_variables.yaml
+++ b/.github/workflows/check_variables.yaml
@@ -1,0 +1,50 @@
+name: check variables
+
+on:
+  pull_request:
+env:
+  SAMPLE_VAR2: context variable
+
+jobs:
+  check_variables:
+    strategy:
+        matrix:
+          environment: [main, variables]
+    runs-on: ubuntu-latest
+    environment: ${{ matrix.environment }}
+    steps:
+      - name: Dump GitHub context
+        run: echo '${{ toJSON(github) }}'
+      - name: Dump SAMPLE_VAR
+        run: |
+          echo "SAMPLE_VAR1=${{ vars.SAMPLE_VAR1 }}"
+          echo "SAMPLE_VAR2=${{ vars.SAMPLE_VAR2 }}"
+  check_envs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump SAMPLE_VAR
+        run: |
+          echo "SAMPLE_VAR1=${{ env.SAMPLE_VAR1}}"
+          echo "SAMPLE_VAR2=${{ env.SAMPLE_VAR2}}"
+      - name: Dump SAMPLE_VAR with step env
+        env:
+          SAMPLE_VAR1: step variable
+          SAMPLE_VAR2: step variable
+        run: |
+          echo "SAMPLE_VAR1=${{ env.SAMPLE_VAR1}}"
+          echo "SAMPLE_VAR2=${{ env.SAMPLE_VAR2}}"
+      - name: override SAMPLE_VAR
+        run: |
+          echo "SAMPLE_VAR1=output" >> $GITHUB_ENV
+          echo "SAMPLE_VAR2=output" >> $GITHUB_ENV
+      - name: Dump SAMPLE_VAR again
+        run: |
+          echo "SAMPLE_VAR1=${{ env.SAMPLE_VAR1}}"
+          echo "SAMPLE_VAR2=${{ env.SAMPLE_VAR2}}"
+      - name: Dump SAMPLE_VAR with step env again
+        env:
+          SAMPLE_VAR1: step variable
+          SAMPLE_VAR2: step variable
+        run: |
+          echo "SAMPLE_VAR1=${{ env.SAMPLE_VAR1}}"
+          echo "SAMPLE_VAR2=${{ env.SAMPLE_VAR2}}"


### PR DESCRIPTION
repository/environments variable で同じキーを指定した場合もどうなるか

- repository variable
- environments variable

条件は

![image](https://user-images.githubusercontent.com/1211775/229982360-573a4ffc-8680-4f93-aa0c-8e1d2ab00bd7.png)
![image](https://user-images.githubusercontent.com/1211775/229982414-0f20a226-0c52-488d-88d2-db01a9ca1a59.png)

- repository variable に SAMPLE_VAR1, SAMPLE_VAR2 を用意
- environments variable に main と variables を用意し， main にだけ SAMPLE_VAR1, SAMPLE_VAR2 を用意
    - これは， env が未設定の場合どうなるか(予測はつくけど)を確認する為

また環境変数を数カ所に設定する事ができるが同じキーを色々な箇所で設定するとどうなるのか?

具体的には以下の3箇所

- `echo KEY=VALUE >> $GITHUB_ENV` による設定
- workflow の root に env として追加
- step 毎に env として追加

(もしかしたらまだあるかもしれないが)これらで同じキーの環境変数を設定した場合に，どれが採用されるかを確認したい．

この PR でそれぞれのパターンでの結果をまとめたらマージする．